### PR TITLE
Support using PasswordAuthenticator with TLS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-version '0.5.0'
+version '0.6.0'
 
 sourceCompatibility = 11
 

--- a/driver/src/main/java/com/intellij/CouchbaseClientURI.java
+++ b/driver/src/main/java/com/intellij/CouchbaseClientURI.java
@@ -135,15 +135,19 @@ class CouchbaseClientURI {
             } else {
                 envBuilder.securityConfig(securityConfig.trustManagerFactory(InsecureTrustManagerFactory.INSTANCE));
             }
-            SslKeyStoreConfig keyStore = SslKeyStoreConfig.create(SslKeyStoreConfig.Type.KEY_STORE);
+        }
+
+        SslKeyStoreConfig keyStore = SslKeyStoreConfig.create(SslKeyStoreConfig.Type.KEY_STORE);
+
+        if(keyStore.getPassword() != null) {
             return CertificateAuthenticator.fromKeyStore(
                     keyStore.getPath(), keyStore.getPassword(), keyStore.getType());
-        } else {
-            if (userName == null || userName.isEmpty() || password == null) {
-                throw new SQLException("Username or password is not provided");
-            }
-            return PasswordAuthenticator.create(userName, password);
         }
+
+        if (userName == null || userName.isEmpty() || password == null) {
+            throw new SQLException("Username or password is not provided");
+        }
+        return PasswordAuthenticator.create(userName, password);
     }
 
     @Nullable

--- a/driver/src/main/java/com/intellij/CouchbaseClientURI.java
+++ b/driver/src/main/java/com/intellij/CouchbaseClientURI.java
@@ -135,13 +135,13 @@ class CouchbaseClientURI {
             } else {
                 envBuilder.securityConfig(securityConfig.trustManagerFactory(InsecureTrustManagerFactory.INSTANCE));
             }
-        }
 
-        SslKeyStoreConfig keyStore = SslKeyStoreConfig.create(SslKeyStoreConfig.Type.KEY_STORE);
+            SslKeyStoreConfig keyStore = SslKeyStoreConfig.create(SslKeyStoreConfig.Type.KEY_STORE);
 
-        if(keyStore.getPassword() != null) {
-            return CertificateAuthenticator.fromKeyStore(
-                    keyStore.getPath(), keyStore.getPassword(), keyStore.getType());
+            if(keyStore.getPassword() != null) {
+                return CertificateAuthenticator.fromKeyStore(
+                        keyStore.getPath(), keyStore.getPassword(), keyStore.getType());
+            }
         }
 
         if (userName == null || userName.isEmpty() || password == null) {

--- a/driver/src/main/java/com/intellij/CouchbaseClientURI.java
+++ b/driver/src/main/java/com/intellij/CouchbaseClientURI.java
@@ -138,7 +138,7 @@ class CouchbaseClientURI {
 
             SslKeyStoreConfig keyStore = SslKeyStoreConfig.create(SslKeyStoreConfig.Type.KEY_STORE);
 
-            if(keyStore.getPassword() != null) {
+            if(userName == null || userName.isEmpty()) {
                 return CertificateAuthenticator.fromKeyStore(
                         keyStore.getPath(), keyStore.getPassword(), keyStore.getType());
             }

--- a/driver/src/main/java/com/intellij/CouchbaseJdbcDriver.java
+++ b/driver/src/main/java/com/intellij/CouchbaseJdbcDriver.java
@@ -64,7 +64,7 @@ public class CouchbaseJdbcDriver implements Driver {
     }
 
     String getVersion() {
-        return "0.5.0";
+        return "0.6.0";
     }
 
     @Override


### PR DESCRIPTION
Currently, the driver requires client certificates to be used when TLS is enabled. This allows username/password to be used in combination with TLS.