### PR TITLE
Upgrade Couchbase Java Client from 3.0.8 to 3.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ sourceSets {
 
 dependencies {
     implementation 'org.jetbrains:annotations:19.0.0'
-    compile 'com.couchbase.client:java-client:3.0.8'
+    compile 'com.couchbase.client:java-client:3.3.4'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/driver/src/main/java/com/intellij/executor/DescribeIndexExecutor.java
+++ b/driver/src/main/java/com/intellij/executor/DescribeIndexExecutor.java
@@ -1,6 +1,6 @@
 package com.intellij.executor;
 
-import com.couchbase.client.core.Core;
+import com.couchbase.client.java.http.CouchbaseHttpClient;
 import com.intellij.CouchbaseConnection;
 import com.intellij.resultset.CouchbaseListResultSet;
 import com.intellij.resultset.CouchbaseResultSetMetaData;
@@ -39,13 +39,13 @@ class DescribeIndexExecutor implements CustomDdlExecutor {
     public ExecutionResult execute(@NotNull CouchbaseConnection connection, @NotNull String sql) throws SQLException {
         Matcher matcher = DESCRIBE_INDEX_PATTERN.matcher(sql);
         if (matcher.matches()) {
-            return new ExecutionResult(true, doRequest(connection.getCluster().core()));
+            return new ExecutionResult(true, doRequest(connection.getCluster().httpClient()));
         }
         return new ExecutionResult(false);
     }
 
-    private static ResultSet doRequest(Core core) throws SQLException {
-        List<Map<String, Object>> rows = getIndexes(core).stream()
+    private static ResultSet doRequest(CouchbaseHttpClient httpClient) throws SQLException {
+        List<Map<String, Object>> rows = getIndexes(httpClient).stream()
                 .map(item -> Collections.singletonMap(ROW_NAME, item))
                 .collect(Collectors.toList());
         CouchbaseListResultSet resultSet = new CouchbaseListResultSet(rows);

--- a/driver/src/main/java/com/intellij/meta/ClusterInfo.java
+++ b/driver/src/main/java/com/intellij/meta/ClusterInfo.java
@@ -1,23 +1,16 @@
 package com.intellij.meta;
 
-import com.couchbase.client.core.Core;
-import com.couchbase.client.core.CoreContext;
-import com.couchbase.client.core.deps.io.netty.handler.codec.http.DefaultFullHttpRequest;
-import com.couchbase.client.core.deps.io.netty.handler.codec.http.HttpMethod;
-import com.couchbase.client.core.deps.io.netty.handler.codec.http.HttpVersion;
-import com.couchbase.client.core.msg.ResponseStatus;
-import com.couchbase.client.core.msg.manager.GenericManagerRequest;
-import com.couchbase.client.core.msg.manager.GenericManagerResponse;
 import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.http.HttpPath;
+import com.couchbase.client.java.http.HttpResponse;
+import com.couchbase.client.java.http.HttpTarget;
 import com.couchbase.client.java.json.JsonObject;
 
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.concurrent.ExecutionException;
 
 public class ClusterInfo {
     private final Cluster cluster;
-    private JsonObject lazyClusterInfo = null;
+    private volatile JsonObject lazyClusterInfo = null;
 
     public ClusterInfo(Cluster cluster) {
         this.cluster = cluster;
@@ -25,28 +18,20 @@ public class ClusterInfo {
 
     public JsonObject getClusterInfo() throws SQLException {
         if (lazyClusterInfo == null) {
-            Core core = cluster.core();
-            GetClusterStatus request = new GetClusterStatus(core.context());
-            core.send(request);
-            GenericManagerResponse response;
             try {
-                response = request.response().get();
-            } catch (InterruptedException | ExecutionException e) {
-                throw new SQLException("Failed to retrieve cluster information");
+                HttpResponse response = cluster.httpClient().get(HttpTarget.manager(), HttpPath.of("/pools"));
+                if (!response.success()) {
+                    throw new SQLException("Failed to retrieve cluster information: "
+                        + "Response status=" + response.statusCode() + " "
+                        + "Response body=" + response.contentAsString());
+                }
+                lazyClusterInfo = JsonObject.fromJson(response.content());
+            } catch (SQLException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new SQLException("Failed to retrieve cluster information", e);
             }
-            if (!response.status().equals(ResponseStatus.SUCCESS)) {
-                throw new SQLException("Failed to retrieve cluster information: "
-                        + "Response status=" + response.status() + " "
-                        + "Response body=" + new String(response.content(), StandardCharsets.UTF_8));
-            }
-            lazyClusterInfo = JsonObject.fromJson(response.content());
         }
         return lazyClusterInfo;
-    }
-
-    private static class GetClusterStatus extends GenericManagerRequest {
-        public GetClusterStatus(CoreContext ctx) {
-            super(ctx, () -> new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/pools"), false);
-        }
     }
 }


### PR DESCRIPTION
Motivation
----------
Recent versions of the Couchbase client support automatically trusting the Certificate Authority certificate required for connecting to Couchbase Capella.


Changes
-------

Bump the Couchbase client version. Fix the resulting issues caused by depending on internal or deprecated APIs:

- Use `CouchbaseHttpClient` to make HTTP requests to the manager service, instead of subclassing deprecated `GenericManagerRequest`.

- When building Couchbase reactive retry specs, call `toReactorRetry()` to get a `Retry` object compatible with Reactor core.

- Fix Jackson deprecation warnings; create the mapper using the new builder method.